### PR TITLE
Fix long literals for python 3 support

### DIFF
--- a/javarandom.py
+++ b/javarandom.py
@@ -40,7 +40,7 @@ class Random(object):
 
     @seed.setter
     def seed(self, seed):
-        self._seed = (seed ^ 0x5deece66dl) & ((1 << 48) - 1)
+        self._seed = (seed ^ 0x5deece66d) & ((1 << 48) - 1)
 
     def next(self, bits):
         """
@@ -56,7 +56,7 @@ class Random(object):
         elif bits > 32:
             bits = 32
 
-        self._seed = (self._seed * 0x5deece66dl + 0xb) & ((1 << 48) - 1)
+        self._seed = (self._seed * 0x5deece66d + 0xb) & ((1 << 48) - 1)
         retval = self._seed >> (48 - bits)
 
         # Python and Java don't really agree on how ints work. This converts


### PR DESCRIPTION
Long literals ending with letter `L` are not longer supported in python 3.

According to this guide: http://python-future.org/compatible_idioms.html#long-integers simply removing the `L` letter is fine for both version (2 adn 3).
